### PR TITLE
remove the tabLength setting

### DIFF
--- a/settings/language-pony.cson
+++ b/settings/language-pony.cson
@@ -1,6 +1,5 @@
 '.source.pony':
   'editor':
-    'tabLength': 2
     'commentStart': '// '
     'foldEndPattern': '^\\s*"""\\s*$'
     'increaseIndentPattern': '^\\s*(type|interface|trait|primitive|class|actor)\\b|\\b(if|then|else|elseif|for|in|do|while|repeat|until|try|with|match|object|recover)\\b((?!end).)*$|(\\([^\\)]*|\\[[^\\]]*)$|=>'


### PR DESCRIPTION
Currently this package forces users to use a tab length of 2 in pony files.
This PR lets atom use the "Tab Length" option in Settings > Editor instead.